### PR TITLE
Ignore "visited target" flag in A* if not using VisitedAGoalAtSomePointInPlanGoalCondition

### DIFF
--- a/src/main/java/BasicMAPF/Solvers/AStar/SingleAgentAStar_Solver.java
+++ b/src/main/java/BasicMAPF/Solvers/AStar/SingleAgentAStar_Solver.java
@@ -340,7 +340,8 @@ public class SingleAgentAStar_Solver extends A_Solver {
             this.prev = prevState;
             this.g = g;
             this.conflicts = conflicts;
-            this.hasVisitedTargetLocationAncestor = isMoveToTargetLocation || (prevState != null && prevState.hasVisitedTargetLocationAncestor);
+            this.hasVisitedTargetLocationAncestor = goalCondition instanceof VisitedAGoalAtSomePointInPlanGoalCondition &&
+                    (isMoveToTargetLocation || (prevState != null && prevState.hasVisitedTargetLocationAncestor));
 
             // must call this last, since it needs some other fields to be initialized already.
             this.h = calcH();


### PR DESCRIPTION
To avoid unnecessarily increasing the size of the search space